### PR TITLE
Fix appearance of 0 upon first load

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -13,10 +13,11 @@ class Player {
   }
 
   retrieveWinsFromStorage() {
-    return this.score = JSON.parse(localStorage.getItem(this.header));
+    this.score = JSON.parse(localStorage.getItem(this.header));
     if (this.score === null || this.score === undefined) {
       this.score = 0;
     }
+    return this.score
   }
 
 }


### PR DESCRIPTION
## Feature Description
>Clearly and concisely describe the feature.

This feature allows for zero to be shown rather than an empty score box upon first load. This also completes one of the noted "Future Iteration & Second Looks" section of the README.

## Problems Encountered
>State any problems encountered.  

 An empty score box, rather than 0 being displayed when there was no score.

## Solution Description
>Describe your code changes in detail for reviewers.

I moved the return score statement in Player so that it was called last. 

## Steps To Take
>Any questions and possible steps moving forward.

I'm so happy I solved this even if the deadline has passed. 

## Output screenshots
>Post output screenshots, if an UI is affected or added due to this feature.
Now a zero appears:
<img width="1436" alt="Screen Shot 2020-11-11 at 2 19 47 PM" src="https://user-images.githubusercontent.com/68332132/98854903-34060180-2429-11eb-8ccc-35754fcc3b7e.png">

Also fixes noted errors/warnings in WAVE extension:
<img width="1436" alt="Screen Shot 2020-11-11 at 2 20 29 PM" src="https://user-images.githubusercontent.com/68332132/98854962-4718d180-2429-11eb-8ab0-70b789fd5184.png">

